### PR TITLE
check if client certificate verification succeed

### DIFF
--- a/src/ulfius.c
+++ b/src/ulfius.c
@@ -371,7 +371,7 @@ static int ulfius_webservice_dispatcher (void * cls, struct MHD_Connection * con
   const union MHD_ConnectionInfo * ci;
   unsigned int listsize;
   const gnutls_datum_t * pcert;
-  gnutls_certificate_status_t client_cert_status;
+  gnutls_certificate_status_t client_cert_status = 0;
   int ret_cert;
 #endif
   char * content_type, * auth_realm = NULL;
@@ -402,7 +402,7 @@ static int ulfius_webservice_dispatcher (void * cls, struct MHD_Connection * con
 #ifndef U_DISABLE_GNUTLS
     ci = MHD_get_connection_info (connection, MHD_CONNECTION_INFO_GNUTLS_SESSION);
     if (((struct _u_instance *)cls)->use_client_cert_auth && ci != NULL && ci->tls_session != NULL) {
-      if ((ret_cert = gnutls_certificate_verify_peers2(ci->tls_session, &client_cert_status)) != 0 && ret_cert != GNUTLS_E_NO_CERTIFICATE_FOUND) {
+      if (((ret_cert = gnutls_certificate_verify_peers2(ci->tls_session, &client_cert_status)) != 0 && ret_cert != GNUTLS_E_NO_CERTIFICATE_FOUND) || client_cert_status != 0) {
         y_log_message(Y_LOG_LEVEL_ERROR, "Ulfius - Error gnutls_certificate_verify_peers2");
       } else if (!ret_cert) {
         pcert = gnutls_certificate_get_peers(ci->tls_session, &listsize);


### PR DESCRIPTION
gnutls_certificate_verify_peers2() returns GNUTLS_E_SUCCESS (0) even in case of certificate verification errors.
The client_cert_status parameters must be checked as noticed in gnutls documentation (see [1]).
This patch adds this check and goes in error branch.
Without this check you can accept a non-trusted certificate and MITM attacks can be done.

[1] https://gnutls.org/manual/gnutls.html#gnutls_005fcertificate_005fverify_005fpeers2